### PR TITLE
Linebreak Delta Option

### DIFF
--- a/webcontent/app.html
+++ b/webcontent/app.html
@@ -36,6 +36,7 @@
             <label>Include /languages <input type="checkbox" name="i_lang" id="incl-languages" checked></label>
             <label>Include /maps <input type="checkbox" name="i_maps" id="incl-maps" checked></label>
             <label>Include /movies <input type="checkbox" name="i_movies" id="incl-movies" checked></label>
+            <label>Include linebreaks in delta <input type="checkbox" name="i_linebreak" id="incl-linebreak" checked></label>
             <p style="margin-bottom:0;">Note: You will be asked about deltas and zipping at their respective stages.</p>
             <p style="margin:0;">Note: You may need as much as 5 GB of free disk space for this process to be successful.</p>
         </form>

--- a/webcontent/app.js
+++ b/webcontent/app.js
@@ -94,6 +94,8 @@ async function s2(p) {
 
     jobDecisions.plugins = await processPluginOptions(modJson, jobs.plugins);
 
+    jobDecisions.linebreak = d.i_linebreak;
+
     await performBundle(modJson, jobDecisions, base, p, jobs.plugins);
 }
 

--- a/webcontent/performBundling.js
+++ b/webcontent/performBundling.js
@@ -53,6 +53,23 @@ function imgToCanvas(img) {
     return ctx;
 }
 
+function formatJson(modJson, linebreak) {
+    let result = JSON.stringify(modJson);
+    // The reason for not full JSON format is to save file size from bloating.
+    // Singular linebreak per operation only adds 1-5% to filesize most of the time,
+    // compared to full giving 20-100% file size
+    if (linebreak) {
+        // Only line break first level, array of objects starting with "op" 
+        // [{"op": stuff},{"op": stuff},...,{"op": stuff}]
+        // It may linebreak more if the data somehow contains that exact format, 
+        // but it should be interrupted by special characters having backslash in actual data
+        result = result.replace(/{"op":/g, "\n{\"op\":");
+        // also linebreak the last bracket, remove last character and add back with newline
+        result = result.slice(0, -1) + "\n]";
+    }
+    return result;
+} 
+
 export async function performBundle(modJson, jobDecisions, gameBase, playtestBase, pluginJob) {
     const tmpBase = path.join(gameBase, "..", ".bundletool_temporary");
     setJobTitle("Building the mod...");
@@ -217,7 +234,7 @@ export async function performBundle(modJson, jobDecisions, gameBase, playtestBas
 
                 let delta = compare(bgdata, ptdata);
                 let noExtFname = dataPath.split(/\.[^\.]+$/)[0];
-                fs.writeFileSync(path.join(tmpBase, "data", `${noExtFname}.${ext}`), JSON.stringify(delta));
+                fs.writeFileSync(path.join(tmpBase, "data", `${noExtFname}.${ext}`), formatJson(delta, jobDecisions.linebreak));
 
                 modJson.files.data.push(ppath.join("data", `${noExtFname}.${ext}`));
             } else {
@@ -254,7 +271,7 @@ export async function performBundle(modJson, jobDecisions, gameBase, playtestBas
 
                 let delta = compare(bgdata, ptdata);
                 let noExtFname = mapPath.split(/\.[^\.]+$/)[0];
-                fs.writeFileSync(path.join(tmpBase, "maps", `${noExtFname}.${ext}`), JSON.stringify(delta));
+                fs.writeFileSync(path.join(tmpBase, "maps", `${noExtFname}.${ext}`), formatJson(delta, jobDecisions.linebreak));
 
                 modJson.files.maps.push(ppath.join("maps", `${noExtFname}.${ext}`));
             } else {
@@ -292,7 +309,7 @@ export async function performBundle(modJson, jobDecisions, gameBase, playtestBas
                 let delta = compare(bgdata, ptdata);
                 langPath = langPath.split("/")[1];
                 let noExtFname = langPath.split(/\.[^\.]+$/)[0];
-                fs.writeFileSync(path.join(tmpBase, "languages", `${noExtFname}.${ext}`), JSON.stringify(delta));
+                fs.writeFileSync(path.join(tmpBase, "languages", `${noExtFname}.${ext}`), formatJson(delta, jobDecisions.linebreak));
 
                 modJson.files.text.push(ppath.join("languages", `${noExtFname}.${ext}`));
             } else {


### PR DESCRIPTION
Adds an option to linebreak delta files.

The linebreak are only on first level, adding newline to `{"op":` string specifically. This allows for compatibility of putting releases on Github or other versioning site, while only adding around 5% size increasing compared to 50%+. This is an extra option people can pick if they do not want it.